### PR TITLE
Allow stating the uuid for a typeform in the yaml

### DIFF
--- a/simplesurvey/survey.py
+++ b/simplesurvey/survey.py
@@ -348,9 +348,9 @@ class Survey():
 class TypeFormSurvey(Survey):
     typeform_url = "https://api.typeform.com/v1/form/{}?key={}"
 
-    def __init__(self, summarizer=None):
+    def __init__(self, form_uuid=None, summarizer=None):
         super().__init__(summarizer)
-        self.form_uuid = None
+        self.form_uuid = form_uuid
         self.api_key = None
 
     @property
@@ -359,7 +359,8 @@ class TypeFormSurvey(Survey):
 
     def config(self, token=None, uuid=None):
         self.api_key = token
-        self.form_uuid = uuid
+        if uuid:
+            self.form_uuid = uuid
 
     def fetch_data(self):
         response = requests.get(self.url)
@@ -399,8 +400,8 @@ class TypeFormSurvey(Survey):
 
 
 def typeform_survey_yaml_constructor(loader, node):
-    survey = TypeFormSurvey()
     values = loader.construct_mapping(node, deep=True)
+    survey = TypeFormSurvey(values.get("uuid"))
     survey.add_columns(values.get("questions", []))
     survey.add_columns(values.get("dimensions", []))
     return survey

--- a/tests/test_survey.py
+++ b/tests/test_survey.py
@@ -42,6 +42,28 @@ def test_typeform_fetch_and_index_responses_by_id():
     assert result == pd.Index(["j.crew@gmail.com"])
 
 
+def test_loading_typeform_survey_from_yaml():
+    document = """
+--- !TypeFormSurvey
+uuid: i-am-a-uuid
+scales:
+  - !OrdinalScale
+    &seven_point_scale
+    labels: [1,2,3,4,5,6,7]
+    ratings: [1,2,3,4,5,6,7]
+questions:
+  - !Question
+    text: "How would you rate the amount of information you received during the Shopify Walkthrough?"
+    column: "walkthrough_rating"
+    scale: *seven_point_scale
+"""
+    try:
+        survey = simplesurvey.LoadSurvey(document)
+        assert survey.form_uuid == "i-am-a-uuid"
+    except Exception as e:
+        pytest.fail("Unexpected Exception: {}".format(e))
+
+
 def test_loading_survey_from_yaml():
     document = """
 --- !Survey


### PR DESCRIPTION
pIcking up the uuid from the yaml as well as allowing it to be set via `config()`