### PR TITLE
Add support for downloading workday reports to dataframes

### DIFF
--- a/simplesurvey/workday.py
+++ b/simplesurvey/workday.py
@@ -1,0 +1,39 @@
+import requests
+import pandas as pd
+
+from requests.auth import HTTPBasicAuth
+
+
+class Report():
+    """ Workday report handles connecting to and downloading json reports from Workday.
+    JSON reports are parsed and returned as a dataframe
+    """
+
+    def __init__(self, user=None, password=None):
+        self.user = user
+        self.password = password
+
+    def config(self, user=None, password=None):
+        if user:
+            self.user = user
+        if password:
+            self.password = password
+
+    def _basic_auth_header(self):
+        return HTTPBasicAuth(self.user, self.password)
+
+    def _workday_request(self, url):
+        r = requests.get(url, auth=self._basic_auth_header())
+        if r.status_code != 200:
+            raise Exception(r.reason)
+        return r.json()
+
+    def _parse_request(self, r):
+        if "Report_Entry" not in r:
+            raise Exception("JSON not in expected format")
+        return r['Report_Entry']
+
+    def fetch_report(self, url):
+        request = self._workday_request(url)
+        json = self._parse_request(request)
+        return pd.DataFrame(json)

--- a/tests/test_workday.py
+++ b/tests/test_workday.py
@@ -1,0 +1,33 @@
+from simplesurvey import workday
+import pandas as pd
+from unittest import mock
+
+
+class MockResponse:
+
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self.json_data
+
+
+def test_workday_fetch_report_and_convert_to_dataframe():
+    data = {"Report_Entry": [
+        {
+            "field1": "2013-11-28",
+            "field2": "type",
+            "field3": "name",
+        }
+    ]}
+
+    def mocked_requests_get(*args, **kwargs):
+        return MockResponse(data, 200)
+
+    with mock.patch('requests.get', side_effect=mocked_requests_get):
+        test_report = workday.Report(user="test", password="test2")
+        result = test_report.fetch_report("https://wd7-services.myworkday.com/ccx/service/somereport/klassenterprises/dana.klassen/super_important_repot?format=json")
+        expected = pd.DataFrame(data['Report_Entry'])
+
+        assert result.equals(expected)


### PR DESCRIPTION
Given a workday report service url, download and convert to a dataframe.